### PR TITLE
build: enable semantic versioning with hatch-vcs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,12 @@
 name: Deploy to TestPyPI
 
 on:
+  push:
+    tags:
+      - "v*"
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -21,12 +25,12 @@ jobs:
       - name: Install build tools
         run: |
             python -m pip install --upgrade pip
-            python -m pip install build
+            pip install -e ".[dev]"
 
       - name: Build package
         run: |
-            python -m build
-
+            hatch build
+            
             echo ""
             echo "Generated files:"
             ls -lh dist/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,15 @@
 
 [build-system]
 build-backend = "hatchling.build"
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 
 ################################################################################
-# Project Configuration.
+# Project Configuration
 ################################################################################
 
 [project]
 name = "travelpy"
-version = "0.2.7"
+dynamic = ["version"]
 
 description = "A lightweight Python package for travel planning"
 authors = [
@@ -45,6 +45,7 @@ Download = "https://test.pypi.org/project/travelpy/#files"
 dev = [
     "hatch",
     "pre-commit",
+    "ruff",
 ]
 
 docs = [
@@ -55,6 +56,7 @@ build = [
     "pip-audit",
     "twine",
 ]
+
 tests = [
     "pytest",
     "pytest-cov",
@@ -75,8 +77,22 @@ only-packages = true
 packages = ["src/travelpy"]
 
 
+################################################################################
+# Semantic Versioning from Git Tags
+################################################################################
 
-######## Configure pytest for your test suite ########
+[tool.hatch.version]
+source = "vcs"
+raw-options = {version_scheme = "no-guess-dev", local_scheme = "no-local-version"}
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/travelpy/__version__.py"
+
+
+################################################################################
+# Pytest Configuration
+################################################################################
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = ["raises"]
@@ -142,7 +158,6 @@ features = [
 [tool.hatch.envs.docs.scripts]
 build = ["quartodoc build && quarto render"]
 serve = ["quarto preview"]
-
 
 
 #--------------- Check security for your dependencies ---------------#


### PR DESCRIPTION
- Add hatch-vcs to build requirements for git tag-based versioning
- Change version from static '0.2.7' to dynamic (from git tags)
- Add [tool.hatch.version] section with VCS source configuration
- Configure automatic __version__.py generation from tags
- Update deploy.yml to trigger on git tags (v*) in addition to releases
- Add ruff to dev dependencies
- Add workflow_dispatch for manual deployment trigger

- [ ] fix #(issue number)
- [ ] description of feature/fix
- [ ] tests added/passed
- [ ] add an entry to the [changelog](../CHANGELOG.md)
